### PR TITLE
Feature: IoC-Container

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(${PROJECT_NAME}
     "main.cpp"
 )
 
-add_dependencies(${PROJECT_NAME} "anthragon_core")
+add_dependencies(${PROJECT_NAME} "anthragon-core")
 target_link_libraries(${PROJECT_NAME}
     "anthragon-core"
 )

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(${PROJECT_NAME}
     "main.cpp"
 )
 
+add_dependencies(${PROJECT_NAME} "anthragon_core")
 target_link_libraries(${PROJECT_NAME}
     "anthragon_core"
 )

--- a/include/anthragon/abi/Anthragon.h
+++ b/include/anthragon/abi/Anthragon.h
@@ -1,0 +1,4 @@
+#pragma once
+
+#define ANT_NAMESPACE anthragon
+

--- a/include/anthragon/core/IoCContainer.h
+++ b/include/anthragon/core/IoCContainer.h
@@ -100,6 +100,67 @@ namespace ANT_NAMESPACE::core
             using Invoker = std::function<std::shared_ptr<void>(std::any& factory)>;
 
         public:
+            /*!
+             * @brief Registers implementation with default constructor
+             * @tparam T ABI to register 
+             * @param locator Locator to register on
+            */
+            template<typename T>
+            void Register(const IoCLocator& locator)
+            {
+                std::function<std::shared_ptr<void>()> defaultFactory =
+                    []()
+                    {
+                        return std::make_shared<T>();
+                    };
+                Register<T>(locator, defaultFactory);
+            }
+
+            /*!
+             * @brief Registers implementation with specific constructors
+             * @tparam T ABI to register
+             * @tparam ...Args Factory arguments
+             * @param locator Locator to register on
+             * @param factory Factory for object construction
+            */
+            template<typename T, typename... Args>
+            void Register(const IoCLocator& locator, const std::function<std::shared_ptr<void>(Args...)>& factory)
+            {
+                auto& registration = m_container[locator];
+                registration.type = RegistrationType::FactoryConstruct;
+                registration.abi = &typeid(T);
+                registration.factory = factory;
+            }
+
+            /*!
+             * @brief Registers an existing object as a IoC singleton
+             * @tparam T ABI to register
+             * @param externalObject external managed object
+            */
+            template<typename T>
+            void RegisterSingleton(const IoCLocator& locator, std::shared_ptr<T> externalObject)
+            {
+                auto& registration = m_container[locator];
+                registration.type = RegistrationType::ExternalSingleton;
+                registration.abi = &typeid(T);
+                registration.subject = std::static_pointer_cast<void, T>(externalObject);
+            }
+
+            /*!
+             * @brief Registers a factory for object creation
+             * @tparam T ABI to register
+             * @tparam ...Args Arguments for singleton construction
+             * @param locator Locator to register on
+             * @param factory Factory for singleton creation
+            */
+            template<typename T, typename... Args>
+            void RegisterSingleton(const IoCLocator& locator, const std::function<std::shared_ptr<void>(Args...)>& factory)
+            {
+                auto& registration = m_container[locator];
+                registration.type = RegistrationType::FactorySingleton;
+                registration.abi = &typeid(T);
+                registration.factory = factory;
+            }
 
             /*!
              * @brief Registers an IoC redirection from source to target

--- a/include/anthragon/core/IoCContainer.h
+++ b/include/anthragon/core/IoCContainer.h
@@ -1,0 +1,204 @@
+#pragma once
+
+#include <anthragon/abi/Anthragon.h>
+
+#include <any>
+#include <string>
+#include <memory>
+#include <typeinfo>
+#include <filesystem>
+#include <functional>
+#include <unordered_map>
+
+namespace ANT_NAMESPACE::core
+{
+    /*!
+     * @brief Path based locator for the IoC container 
+    */
+    using IoCLocator = std::filesystem::path;
+
+    /*!
+     * @brief The IoC container is used to register ABI implementations
+    */
+    class IoCContainer
+    {
+        public:
+            /*!
+             * @brief How the registration is to be interpreted (Factory, singleton, etc.)
+            */
+            enum class RegistrationType
+            {
+                /*!
+                 * @brief The registration is invalid
+                */
+                Null = 0, 
+
+                /*!
+                 * @brief The registered implementation is an external T* 
+                */
+                ExternalSigelton,
+
+                /*!
+                 * @brief The registered implementation is a factory for creating a single instance
+                */
+                FactorySingelton,
+
+                /*!
+                 * @brief The registered implementation is a factory for creating objects
+                */
+                FactoryConstruct,
+
+                /*!
+                 * @brief The registered entity redirects to another implementation
+                */
+                Redirect,
+            };
+
+        private:
+            /*!
+             * @brief IoC registration entry
+            */
+            struct Registration
+            {
+                /*!
+                 * @brief Indicates how to interpret the stored content
+                */
+                RegistrationType type = RegistrationType::Null;
+
+                /*!
+                 * @brief Type of the ABI that the function implements
+                */
+                const std::type_info* abi = nullptr;
+
+                /*!
+                 * @brief Registration to redirect to on request. Only valid when "type" = "RegistrationType::Redirect"
+                */
+                IoCLocator redirect;
+
+                /*!
+                 * @brief Registration subject. "Pointer to instance" as std::shared_ptr<void>. Only valid when 
+                 * "type" = "RegistrationType::ExternalSigelton" or "RegistrationType::FactorySingelton"
+                */
+                std::any subject;
+
+                /*!
+                 * @brief Factory to create subject / instance. As std::function<std::shared_ptr<void>()> Only valid 
+                 * when "type" = "RegistrationType::FactorySingelton" or "type" = "RegistrationType::FactoryConstruct"
+                */
+                std::any factory;
+            };
+
+            /*!
+             * @brief Inner container type
+            */
+            using Container = std::unordered_map<IoCLocator, Registration>;
+
+            /*!
+             * @brief An invoker is used as a proxy between IoC containers implementation (static c++)
+             * And template generative calls to IoC containers Get().
+            */
+            using Invoker = std::function<std::shared_ptr<void>(std::any& factory)>;
+
+        public:
+
+            /*!
+             * @brief Registers an IoC redirection from source to target
+             * @param source Source locator to which shall be listen to. Will always override exiting registrations!
+             * @param target Target locator to which shall be redirect to. Target will undergo an normal query!
+             * @return True if source existed and target could be installed. 
+            */
+            bool RegisterRedirect(const IoCLocator& source, const IoCLocator& target);
+
+            /*!
+             * @brief Complex / Get construct function
+             * @tparam T ABI Type to retrieve
+             * @tparam ...Args Optional arguments for construction
+             * @param locator Input locator to query
+             * @param ...args Optional arguments for construction
+             * @return Retrieve instance
+            */
+            template<typename T, typename... Args>
+            std::shared_ptr<T> Get(const IoCLocator& locator, Args... args)
+            {
+                auto invoker = 
+                    [&](std::any& factory)
+                    {
+                        return std::any_cast<std::function<std::shared_ptr<void>(Args...)>>(factory)(std::forward<Args>(args)...);
+                    };
+
+                RegistrationType h;
+                auto rv = std::static_pointer_cast<T, void>(Get(locator, &typeid(T), h, invoker));
+                return rv;
+            }
+
+            /*!
+             * @brief Complex / Get construct function
+             * @tparam T ABI Type to retrieve
+             * @tparam ...Args Optional arguments for construction
+             * @param locator Input locator to query
+             * @param ...args Optional arguments for construction
+             * @param hint Optional pointer to output hint (how object was retrieved)
+             * @return Retrieve instance
+            */
+            template<typename T, typename... Args>
+            std::shared_ptr<T> Get(const IoCLocator& locator, RegistrationType* hint, Args... args)
+            {
+                auto invoker =
+                    [&](std::any& factory)
+                {
+                    return std::any_cast<std::function<std::shared_ptr<void>(Args...)>>(factory)(std::forward<Args>(args)...);
+                };
+
+                RegistrationType h;
+                auto rv = std::static_pointer_cast<T, void>(Get(locator, &typeid(T), h, invoker));
+                if (hint)
+                {
+                    *hint = h;
+                }
+                return rv;
+            }
+
+            /*!
+             * @brief Most simple get (only use locator)
+             * 
+             * This function only works on objects that are already constructed or don't need parameters for construction
+             * @param locator Input locator to query
+             * @param hint Optional pointer to output hint (how object was retrieved)
+             * @return 
+            */
+            std::shared_ptr<void> Get(const IoCLocator& locator, RegistrationType* hint = nullptr);
+
+        private:
+            /*!
+             * @brief Will walk the IoC container by given locator (and abi) to find matching entry
+             * @param locator Input locator
+             * @param abi ABI to check entry against. Can be null -> checks will skipp
+             * @param hint Output hint to indicate registration type
+             * @param invoker Invoker proxy for factories
+             * @return Shared pointer as void or nullptr
+            */
+            std::shared_ptr<void> Get(const IoCLocator& locator, const std::type_info* abi, RegistrationType& hint, const Invoker& invoker);
+
+            /*!
+             * @brief Iteratively query's the container for a matching entry
+             * @param locator Input locator (Will query as is plus all "nm/.../*" combinations
+             * @return Element iterator or end
+            */
+            Container::iterator Query(const IoCLocator& locator);
+
+            /*!
+             * @brief Default invoker implementation 
+             * 
+             * (direct forward to parameterless factory)
+             * @param factory Factory to forward
+             * @return Pointer to instance
+            */
+            static std::shared_ptr<void> DefaultInvoker(std::any& factory);
+
+        private:
+            /*!
+             * @brief Container instance
+            */
+            Container m_container;
+    };
+}

--- a/include/anthragon/core/IoCContainer.h
+++ b/include/anthragon/core/IoCContainer.h
@@ -36,12 +36,12 @@ namespace ANT_NAMESPACE::core
                 /*!
                  * @brief The registered implementation is an external T* 
                 */
-                ExternalSigelton,
+                ExternalSingleton,
 
                 /*!
-                 * @brief The registered implementation is a factory for creating a single instance
+                 * @brief The registered implementation is a factory for creating a single instance Singleton
                 */
-                FactorySingelton,
+                FactorySingleton,
 
                 /*!
                  * @brief The registered implementation is a factory for creating objects

--- a/include/anthragon/core/UseDummy.h
+++ b/include/anthragon/core/UseDummy.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <anthragon/abi/IDummy.h>
+#include <anthragon/core/IoCContainer.h>
 
 /*!
  * @brief Just some trash

--- a/src/anthragon/core/CMakeLists.txt
+++ b/src/anthragon/core/CMakeLists.txt
@@ -6,6 +6,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_library(${PROJECT_NAME}
     "UseDummy.cpp"
+    "IoCContainer.cpp"
 )
 
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
 target_include_directories(${PROJECT_NAME} PUBLIC "${CMAKE_SOURCE_DIR}/include")

--- a/src/anthragon/core/IoCContainer.cpp
+++ b/src/anthragon/core/IoCContainer.cpp
@@ -1,0 +1,118 @@
+#include "anthragon/core/IoCContainer.h"
+
+std::shared_ptr<void> ANT_NAMESPACE::core::IoCContainer::Get(const IoCLocator& locator, RegistrationType* hint /*= nullptr*/)
+{
+    RegistrationType h;
+    auto rv = Get(locator, nullptr, h, &IoCContainer::DefaultInvoker);
+    if (hint)
+    {
+        *hint = h;
+    }
+    return rv;
+}
+
+std::shared_ptr<void> ANT_NAMESPACE::core::IoCContainer::Get(const IoCLocator& locator, const std::type_info* abi, RegistrationType& hint, const Invoker& invoker)
+{
+    hint = RegistrationType::Null;
+
+    auto it = Query(locator);
+    if (it != m_container.end())
+    {
+        auto registration = it->second;
+        if (!abi || registration.abi == abi)
+        {
+            switch (registration.type)
+            {
+                // Simple type
+                case RegistrationType::Redirect:
+                    return Get(registration.redirect, abi, hint, invoker);
+
+                case RegistrationType::ExternalSigelton:
+                    hint = RegistrationType::ExternalSigelton;
+                    return std::any_cast<std::shared_ptr<void>>(registration.subject);
+
+                // Factory based (invoker)
+                case RegistrationType::FactorySingelton:
+                    hint = RegistrationType::FactorySingelton;
+                    if (!registration.subject.has_value())
+                    {
+                        registration.subject = invoker(registration.factory);
+                    }
+                    return std::any_cast<std::shared_ptr<void>>(registration.subject);
+
+                case RegistrationType::FactoryConstruct:
+                    hint = RegistrationType::FactoryConstruct;
+                    return invoker(registration.factory);
+            }
+        }
+    }
+    return nullptr;
+}
+
+ANT_NAMESPACE::core::IoCContainer::Container::iterator ANT_NAMESPACE::core::IoCContainer::Query(const IoCLocator& locator)
+{
+    // Step 1: Query 1:1
+    Container::iterator it = m_container.find(locator);
+    if (it != m_container.end())
+    {
+        return it;
+    }
+
+    // Step 2: Query nm/nm/* -> nm/*
+    std::string l = locator.string();
+    auto dpos = l.find_last_of('/');
+    if (dpos != std::string::npos)
+    {
+        l = l.substr(0, dpos + 1);
+        l += "*";
+        
+        while (true)
+        {
+            it = m_container.find(l);
+            if (it != m_container.end())
+            {
+                return it;
+            }
+
+            l = l.substr(0, l.size() - 2);
+            dpos = l.find_last_of('/');
+            if (dpos == std::string::npos)
+            {
+                break;
+            }
+            l = l.substr(0, dpos + 1);
+            l += "*";
+        }
+    }
+
+    // Step 3: Return end
+    return m_container.end();
+}
+
+std::shared_ptr<void> ANT_NAMESPACE::core::IoCContainer::DefaultInvoker(std::any& factory)
+{
+    return std::any_cast<std::function<std::shared_ptr<void>()>>(factory)();
+}
+
+bool ANT_NAMESPACE::core::IoCContainer::RegisterRedirect(const IoCLocator& source, const IoCLocator& target)
+{
+    auto itTarget = Query(target);
+    if (itTarget != m_container.end())
+    {
+        // Erase existing
+        auto itSource = m_container.find(source); // Normal find because we are installing a "original" locator
+        if (itSource != m_container.end())
+        {
+            m_container.erase(itSource);
+        }
+
+        // Install redirect
+        auto& registration = m_container[source];
+        registration.type = RegistrationType::Redirect;
+        registration.redirect = target;
+        registration.abi = itTarget->second.abi; // Serves same abi
+
+        return true;
+    }
+    return false;
+}

--- a/src/anthragon/core/IoCContainer.cpp
+++ b/src/anthragon/core/IoCContainer.cpp
@@ -18,7 +18,7 @@ std::shared_ptr<void> ANT_NAMESPACE::core::IoCContainer::Get(const IoCLocator& l
     auto it = Query(locator);
     if (it != m_container.end())
     {
-        auto registration = it->second;
+        auto& registration = it->second;
         if (!abi || registration.abi == abi)
         {
             switch (registration.type)

--- a/src/anthragon/core/IoCContainer.cpp
+++ b/src/anthragon/core/IoCContainer.cpp
@@ -27,13 +27,13 @@ std::shared_ptr<void> ANT_NAMESPACE::core::IoCContainer::Get(const IoCLocator& l
                 case RegistrationType::Redirect:
                     return Get(registration.redirect, abi, hint, invoker);
 
-                case RegistrationType::ExternalSigelton:
-                    hint = RegistrationType::ExternalSigelton;
+                case RegistrationType::ExternalSingleton:
+                    hint = RegistrationType::ExternalSingleton;
                     return std::any_cast<std::shared_ptr<void>>(registration.subject);
 
                 // Factory based (invoker)
-                case RegistrationType::FactorySingelton:
-                    hint = RegistrationType::FactorySingelton;
+                case RegistrationType::FactorySingleton:
+                    hint = RegistrationType::FactorySingleton;
                     if (!registration.subject.has_value())
                     {
                         registration.subject = invoker(registration.factory);

--- a/src/anthragon/core/UseDummy.cpp
+++ b/src/anthragon/core/UseDummy.cpp
@@ -16,9 +16,29 @@
  */
 #include <anthragon/core/UseDummy.h>
 
+class DumIn : public IDummy
+{
+    public:
+        DumIn(int _a, int _b) : a(_a), b(_b) {}
+
+        void CallDummy() override
+        {
+            throw std::logic_error("The method or operation is not implemented.");
+        }
+
+    private:
+        int a, b;
+};
+
+std::shared_ptr<void> Factory(int a, int b)
+{
+    return std::make_shared<DumIn>(DumIn{a, b});
+}
+
 void UseDummy()
 {
-    IDummy* dummy = nullptr;
+    anthragon::core::IoCContainer container;
+    auto dummy = container.Get<IDummy>("widgets/button/anthragon", 5, 3);
     if (dummy)
     {
         dummy->CallDummy();

--- a/src/anthragon/core/UseDummy.cpp
+++ b/src/anthragon/core/UseDummy.cpp
@@ -26,21 +26,37 @@ class DumIn : public IDummy
             throw std::logic_error("The method or operation is not implemented.");
         }
 
+        static std::shared_ptr<void> Factory(int a, int b)
+        {
+            return std::make_shared<DumIn>(DumIn{ a, b });
+        }
+
     private:
         int a, b;
 };
 
-std::shared_ptr<void> Factory(int a, int b)
-{
-    return std::make_shared<DumIn>(DumIn{a, b});
-}
-
 void UseDummy()
 {
     anthragon::core::IoCContainer container;
-    auto dummy = container.Get<IDummy>("widgets/button/anthragon", 5, 3);
-    if (dummy)
-    {
-        dummy->CallDummy();
-    }
+
+    // External singleton
+    auto d1 = std::make_shared<DumIn>(1, 2);
+    container.RegisterSingleton<IDummy>("d1", d1);
+    auto d1x = container.Get<IDummy>("d1");
+
+    // Factory (singleton)
+    container.RegisterSingleton<IDummy, int, int>("d2", &DumIn::Factory);
+    auto d2x = container.Get<IDummy>("d2", 3, 4);
+    auto d2x2 = container.Get<IDummy>("d2", 5, 6);
+    auto d2x3 = container.Get<IDummy>("d2");
+
+    // Object
+    container.Register<IDummy, int, int>("d3", &DumIn::Factory);
+    auto d3x = container.Get<IDummy>("d3", 11, 12);
+    auto d3x2 = container.Get<IDummy>("d3", 21, 22);
+    auto d3x3 = container.Get<IDummy>("d3", 31, 32);
+
+    // Redirect
+    container.RegisterRedirect("default", "d3");
+    auto ddf = container.Get<IDummy>("default", 101, 102);
 }


### PR DESCRIPTION
Adding the basic locator based IoC-Container. Locators are a file-system like string `my/path/to/abi`. Query works recursively so that `my/path/to/abi` will query in order:

- `my/path/to/abi`
- `my/path/to/*`
- `my/path/*`
- `my/*` 

Features:

- Registration of external singletons (void*/T*)
- Registration of managed singletons via factory (with / without arguments)
- Registration of managed object creation via factory (with / without arguments)
- Registration of redirects that point from one locator to another
- Resolving can be done via template with arguments, via template without arguments and as a direct function call. The template based calls will do ABI validation, while the non template one does not.

To-Do List:
- [x] Implement `Get<T>()`
- [x] Implement `Get()`
- [x] Implement `RegisterSingleton<T>(T*)`
- [x] Implement `RegisterSingleton<T>(factory)`
- [x] Implement `Register<T>()`
- [x] Implement `Register<T>(factory)`
- [x] Implement `RegisterRedirect()` 
- [x] Check if it works